### PR TITLE
Display index bloat percentage

### DIFF
--- a/app/views/pg_hero/home/index_bloat.html.erb
+++ b/app/views/pg_hero/home/index_bloat.html.erb
@@ -26,6 +26,7 @@ ALTER INDEX new_index RENAME TO index;</code></pre>
         <tr>
           <th>Index</th>
           <th style="width: 15%;">Bloat</th>
+          <th style="width: 15%;">Percent</th>
           <th style="width: 15%;">Size</th>
         </tr>
       </thead>
@@ -39,6 +40,7 @@ ALTER INDEX new_index RENAME TO index;</code></pre>
               <% end %>
             </td>
             <td><%= PgHero.pretty_size(index[:bloat_bytes]) %></td>
+            <td><%= PgHero.pretty_size(index[:bloat_pct]) %></td>
             <td><%= PgHero.pretty_size(index[:index_bytes]) %></td>
           </tr>
           <% if @show_sql && !index[:primary] %>

--- a/app/views/pg_hero/home/index_bloat.html.erb
+++ b/app/views/pg_hero/home/index_bloat.html.erb
@@ -40,7 +40,7 @@ ALTER INDEX new_index RENAME TO index;</code></pre>
               <% end %>
             </td>
             <td><%= PgHero.pretty_size(index[:bloat_bytes]) %></td>
-            <td><%= PgHero.pretty_size(index[:bloat_pct]) %></td>
+            <td><%= PgHero.pretty_pct(index[:bloat_pct]) %></td>
             <td><%= PgHero.pretty_size(index[:index_bytes]) %></td>
           </tr>
           <% if @show_sql && !index[:primary] %>

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -191,6 +191,10 @@ module PgHero
       ActiveSupport::NumberHelper.number_to_human_size(value, precision: 3)
     end
 
+    def pretty_pct(value)
+      ActiveSupport::NumberHelper.number_to_percentage(value)
+    end
+
     # delete previous stats
     # go database by database to use an index
     # stats for old databases are not cleaned up since we can't use an index

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -192,7 +192,7 @@ module PgHero
     end
 
     def pretty_pct(value)
-      ActiveSupport::NumberHelper.number_to_percentage(value)
+      ActiveSupport::NumberHelper.number_to_percentage(value, precision: 0)
     end
 
     # delete previous stats

--- a/lib/pghero/methods/indexes.rb
+++ b/lib/pghero/methods/indexes.rb
@@ -307,6 +307,7 @@ module PgHero
             table_name AS table,
             index_name AS index,
             wastedbytes AS bloat_bytes,
+            round(realbloat, 1) as bloat_pct,
             totalbytes AS index_bytes,
             pg_get_indexdef(rb.indexrelid) AS definition,
             indisprimary AS primary
@@ -317,7 +318,8 @@ module PgHero
           WHERE
             wastedbytes >= #{min_size.to_i}
           ORDER BY
-            wastedbytes DESC,
+            bloat_pct DESC,
+            wastedbytes,
             index_name
         SQL
       end


### PR DESCRIPTION
This change adds a `Percent` column and orders the results by this column in descending order. That way an administrator can focus on the indexes with the highest bloat percentage, and work their way down to the less bloated indexes.


<img width="759" alt="PgHero___Index_Bloat" src="https://user-images.githubusercontent.com/2161008/133655769-1779f085-5089-4039-be85-17137bbc3076.png">

Compare the bloat bytes to the total index bytes, as a percentage. Order
the index bloat by bloat percentage. These are the indexes that may
benefit the most from a reindex. Particularly if the indexes are on a
heavily written or queried table.

The associated tables may also require additional Autovacuum resources
directed towards their automatic vacuums, to make sure it is tuned
appropriately for the workload.

High bloat ratio may affect query planner index selection and index only scan query
performance.

References:

* https://medium.com/compass-true-north/dealing-with-significant-postgres-database-bloat-what-are-your-options-a6c1814a03a5
* https://www.cybertec-postgresql.com/en/detecting-table-bloat/